### PR TITLE
Add responsive support to AoC Input form

### DIFF
--- a/lib/assets/helper_cell/main.css
+++ b/lib/assets/helper_cell/main.css
@@ -36,7 +36,7 @@ button {
   flex-wrap: wrap;
   padding: 8px 16px;
   gap: 8px;
-	height: 100%;
+  height: 100%;
   min-height: 100%;
 }
 
@@ -63,7 +63,7 @@ button {
   border-radius: 0.5rem;
   /* border-bottom: solid 1px var(--gray-200); */
   gap: 16px;
-	height: 100%;
+  height: 100%;
   min-height: 100%;
 }
 
@@ -104,7 +104,7 @@ input[required].empty {
 
 .input--xs {
   width: auto;
-  min-width: 120px;
+  min-width: 80px;
 }
 
 .input--text {
@@ -148,8 +148,22 @@ input[required].empty {
 }
 
 .grow {
-  flex: 1 1 0px;
+  flex-basis: 100%;
   width: 0;
+}
+
+@media screen and (min-width: 350px) {
+  .grow {
+    flex: 1 0 45%;
+    width: 0;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .grow {
+    flex: 1 1 0px;
+    width: 0;
+  }
 }
 
 .help-box {


### PR DESCRIPTION
Hello!
I've been doing AoC with a second, more narrow window to the side of my working window scrolled down to my test runner to be able to see test results without scrolling. With this more narrow screen the input fields overlapping keep catching my eye.

### Narrow width now:
![current](https://user-images.githubusercontent.com/454563/206800485-eae2c39e-cc20-439a-8a1c-a56d1c61c052.png)

## Changes
### Large(same)
![lg](https://user-images.githubusercontent.com/454563/206800570-a9e1aadc-3145-4084-8c98-2d18fa18bb06.png)

### Medium
![md](https://user-images.githubusercontent.com/454563/206800609-c9fd686c-4661-4b6f-b46e-479f502a28f7.png)

### Small
![sm](https://user-images.githubusercontent.com/454563/206800631-2a3494a4-8a3c-419a-8d17-4b7ab1ebd614.png)

