### PR TITLE
Use existing session secret

### DIFF
--- a/lib/kino_aoc/helper_cell.ex
+++ b/lib/kino_aoc/helper_cell.ex
@@ -14,7 +14,7 @@ defmodule KinoAOC.HelperCell do
       "year" => attrs["year"],
       "day" => attrs["day"],
       "session" => session,
-      "session_secret" => attrs["set_session"] || "",
+      "session_secret" => attrs["session_secret"] || "",
       "use_session_secret" => Map.has_key?(attrs, "session_secret") || session == ""
     }
 


### PR DESCRIPTION
Hello!
Currently, when reloading the smart cell via running the Mix.install portion of the LiveBook, the `session_secret` attribute is cleared.
This means when opening an existing notebook or adding a dependency to the one you're working on requires you to re-add your session secret to the smart cell.

When loading `session_secret` it attempted to load a `set_session` attribute which does not seem to be referenced anywhere else. I've changed that to load `session_secret` back into `session_secret`.


## Before

https://user-images.githubusercontent.com/454563/230999288-315f670e-ef4a-4bab-a54d-29b977c8ba8f.mp4


## After

https://user-images.githubusercontent.com/454563/230999300-8d567a55-085f-4a69-b840-bc1592311a2c.mp4
