### PR TITLE
fix: Trim the last "\n" with trim_trailing

### DIFF
--- a/lib/kino_aoc.ex
+++ b/lib/kino_aoc.ex
@@ -35,7 +35,7 @@ defmodule KinoAOC do
       )
 
     case res.status do
-      200 -> {:ok, String.slice(res.body, 0..-2//1)}
+      200 -> {:ok, String.trim_trailing(res.body, "\n")}
       _ -> raise "\nStatus: #{inspect(res.status)}\nError: #{inspect(String.trim(res.body))}"
     end
   end


### PR DESCRIPTION
In cases like Day 1 or Day 3 of Advent of Code 2015, where the input lacks a trailing "\n", the correct input could not be obtained. The issue has been resolved by using `String.trim_trailing`